### PR TITLE
CI: fix trigger branch condition for renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,13 +2,12 @@ name: Renovate
 
 on:
   pull_request:
-    branches:
-      - 'renovate/**'
     paths:
       - '**/Package.swift'
 
 jobs:
   resolve_package_dependencies:
+    if: ${{ startsWith(github.head_ref, 'renovate/') }}
     runs-on: macos-12
     timeout-minutes: 5
     env:
@@ -31,7 +30,7 @@ jobs:
         continue-on-error: true
 
       - name: Commit and Push
-        if: steps.diff.outcome == 'failure'
+        if: ${{ steps.diff.outcome == 'failure' }}
         run: |
           set -x
           git config user.name github-actions[bot]


### PR DESCRIPTION
Fix mistake on #41 

Run renovate workflow based on the pull request's head branch name (as opposed to the pull request's base branch name).

## refs

- [特定のブランチ名のプルリクエストで動作するGitHub Actionsを作る](https://zenn.dev/ryo_kawamata/articles/github-actions-specific-branch)
- [Events that trigger workflows - GitHub Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request)